### PR TITLE
Avoid verifying SSL

### DIFF
--- a/bulk_score.py
+++ b/bulk_score.py
@@ -29,7 +29,7 @@ async def get(mode, api_key, param):
             login=api_key,
             password=''
         )
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(verify_ssl=False)) as session:
             async with throttler:
                 async with session.get(url=url, auth=auth, params=params) as response:
                     return await response.json()


### PR DESCRIPTION
Asana: https://app.asana.com/0/674611063356728/1185945890610779
This change makes the verification of the SSL optional, to avoid the "CERTIFICATE_VERIFY_FAIL" error. Because we're just calling app.madkudu.com, this is totally fine.